### PR TITLE
Fix: change port number in queue page

### DIFF
--- a/pages/queue.js
+++ b/pages/queue.js
@@ -47,7 +47,8 @@ const Queue = (props) => (
 Queue.getInitialProps = async ({query},res) => {
     console.log(query,"::query")
     console.log(res,"::res")
-    const resp = await fetch('http://localhost:3000/queuedata')
+    const port = process.env.PORT || 5000;
+    const resp = await fetch(`http://localhost:${port}/queuedata`);
     const data = await resp.json()
     return {data}
 }


### PR DESCRIPTION
The queue page hits the wrong url. The port has been changed to hit the correct route.

I was seeing this error: 

![Screenshot from 2020-02-26 00-27-33](https://user-images.githubusercontent.com/23582438/75279847-5b348880-5832-11ea-9584-822765a7b80d.png)
