### PR TITLE
docker-compose for easy redis setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+email = -- your email --
+password = -- email password --
+NODE_ENV = dev
+access_key = -- internet-archive-access-key --
+secret_key = -- internet-archive-secret-key --
+GB_KEY = -- google-books-key --
+redishost = -- redis-host --
+redisport = -- redis-port --
+service = -- email service provider --

--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,0 @@
-email = -- your email --
-password = -- email password --
-NODE_ENV = dev
-access_key = -- internet-archive-access-key --
-secret_key = -- internet-archive-secret-key --
-GB_KEY = -- google-books-key --
-redishost = -- redis-host --
-redisport = -- redis-port --
-service = -- email service provider --

--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ A book uploader bot that transfers documents from public libraries such as Googl
 ## Getting Started
 1. Install [Node](https://nodejs.org/en/download/). Check for Node and NPM correct install using `node -v` and `npm -v` on the terminal.
 2. Install [Docker toolbox](https://docs.docker.com/toolbox/toolbox_install_windows/).
-3. Start redis service in the background using : `docker run --name redis -p 6379:6379 redis` and `docker start redis` . Note that redis server can also be run in other different possible ways, apart from the one mentioned in this point.
+3. Start redis service in the background 
+* Using Docker :
+`docker run --name redis -p 6379:6379 redis` and `docker start redis` . 
+
+* Using `docker-compose` : 
+`docker-compose up`
 4. Note: In order to send email through gmail, you may need to allow less secure app access. To turn it on, go to https://myaccount.google.com/lesssecureapps?pli=1
 5. Clone the repository `git clone https://github.com/coderwassananmol/BUB2`
 6. Navigate to the project directory on the terminal: `cd BUB2`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A book uploader bot that transfers documents from public libraries such as Googl
 `docker run --name redis -p 6379:6379 redis` and `docker start redis` . 
 
 * Using `docker-compose` : 
-`docker-compose up`
+`docker-compose up -d` and `docker-compose start`
 4. Note: In order to send email through gmail, you may need to allow less secure app access. To turn it on, go to https://myaccount.google.com/lesssecureapps?pli=1
 5. Clone the repository `git clone https://github.com/coderwassananmol/BUB2`
 6. Navigate to the project directory on the terminal: `cd BUB2`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,7 @@
 version: '3'
 services:
   redis:
-    container_name: redis
     image: redis
     ports:
       - "6379:6379"
-    volumes:
-      - ../data/redis:/data
-    entrypoint: redis-server --appendonly yes
     restart: always
-
-networks:
-  redis-net:
-
-volumes:
-  redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  redis:
+    container_name: redis
+    image: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - ../data/redis:/data
+    entrypoint: redis-server --appendonly yes
+    restart: always
+
+networks:
+  redis-net:
+
+volumes:
+  redis-data:


### PR DESCRIPTION
This PR involves adding a ```docker-compose``` file to easily setup ```redis```.
It closes issue #29 
@ankitjena Please review and suggest me any changes.