### PR TITLE
Add `_app.js` file and Codex

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import Head from "next/head";
 import Link from "next/link";
 import Octicon, { Star, RepoForked } from "@primer/octicons-react";
 
@@ -22,47 +21,6 @@ class Header extends Component {
   render() {
     return (
       <div>
-        <Head>
-          <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
-          ></meta>
-          <link
-            rel="stylesheet"
-            href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
-            integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
-            crossOrigin="anonymous"
-          />
-          <title>Book Uploader Bot</title>
-          <link
-            rel="stylesheet"
-            href="https://unpkg.com/nprogress@0.2.0/nprogress.css"
-          />
-
-          <link
-            rel="stylesheet"
-            href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css"
-            integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp"
-            crossOrigin="anonymous"
-          />
-          <link
-            href="https://fonts.googleapis.com/css?family=Montserrat:300|Open+Sans:300|Raleway:300|Lato:700"
-            rel="stylesheet"
-          />
-
-          {/* Favicons */}
-          <meta
-            name="msapplication-TileImage"
-            content="assets/mstile-150x150.png"
-          />
-          <link rel="shortcut icon" href="assets/favicon.ico" />
-          <link rel="icon" type="image/png" href="assets/favicon.ico" />
-          <link
-            rel="icon"
-            sizes="196x196"
-            href="assets/apple-touch-icon.png"
-          ></link>
-        </Head>
         <nav className="navbar navbar-default" style={{ marginBottom: "0px" }}>
           <div className="container-fluid">
             <div className="navbar-header">

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "winston": "^3.9.0"
   },
   "devDependencies": {
+    "@wikimedia/codex": "^0.13.0",
+    "@wikimedia/codex-design-tokens": "^0.13.0",
     "husky": "^4.2.3",
     "lint-staged": "^10.0.9",
     "prettier": "2.0.2"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,49 @@
+import Head from "next/head";
+
+// import global styles
+import "./../styles/global.css";
+
+function MyApp({ Component, pageProps }) {
+  return (
+    <div>
+      <Head>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+        ></meta>
+        {/* include bootstrap stylesheet */}
+        <link
+          rel="stylesheet"
+          href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
+          crossOrigin="anonymous"
+        />
+        {/* stylesheet for the progress bar */}
+        <link
+          rel="stylesheet"
+          href="https://unpkg.com/nprogress@0.2.0/nprogress.css"
+        />
+        <link
+          href="https://fonts.googleapis.com/css?family=Montserrat:300|Open+Sans:300|Raleway:300|Lato:700"
+          rel="stylesheet"
+        />
+        <title>Book Uploader Bot</title>
+        {/* Favicons */}
+        <meta
+          name="msapplication-TileImage"
+          content="assets/mstile-150x150.png"
+        />
+        <link rel="shortcut icon" href="assets/favicon.ico" />
+        <link rel="icon" type="image/png" href="assets/favicon.ico" />
+        <link
+          rel="icon"
+          sizes="196x196"
+          href="assets/apple-touch-icon.png"
+        ></link>
+      </Head>
+      <Component {...pageProps} />
+    </div>
+  );
+}
+
+export default MyApp;

--- a/styles/global.css
+++ b/styles/global.css
@@ -1,0 +1,1 @@
+@import '@wikimedia/codex/dist/codex.style.css'


### PR DESCRIPTION
Add custom `_app.js` file to contain import of CDNs, external stylesheets, fonts, metadata, and include relevant Codex packages

Bug: [T340683](https://phabricator.wikimedia.org/T340683)