### PR TITLE
Fixes[T348186]: add authors to internet-archive metadata

### DIFF
--- a/bull/google-books-queue/consumer.js
+++ b/bull/google-books-queue/consumer.js
@@ -67,7 +67,7 @@ GoogleBooksQueue.process((job, done) => {
           "X-archive-meta-licenseurl":
             "https://creativecommons.org/publicdomain/mark/1.0/",
           "X-archive-meta-publisher": publisher.trim(),
-          "X-archive-meta-authors": authors.join().trim(),
+          "X-archive-meta-Author": authors.join().trim(),
           "X-archive-meta-rights": accessViewStatus.trim(),
           "X-archive-meta-Google-id": id,
           "X-archive-meta-Identifier": `bub_gb_${id}`,

--- a/bull/google-books-queue/consumer.js
+++ b/bull/google-books-queue/consumer.js
@@ -28,6 +28,7 @@ GoogleBooksQueue.process((job, done) => {
   const { id, volumeInfo, accessInfo } = job.data.details;
   const jobLogs = volumeInfo;
   let {
+    authors,
     publisher,
     publishedDate,
     imageLinks,
@@ -66,6 +67,7 @@ GoogleBooksQueue.process((job, done) => {
           "X-archive-meta-licenseurl":
             "https://creativecommons.org/publicdomain/mark/1.0/",
           "X-archive-meta-publisher": publisher.trim(),
+          "X-archive-meta-authors": authors.join().trim(),
           "X-archive-meta-rights": accessViewStatus.trim(),
           "X-archive-meta-Google-id": id,
           "X-archive-meta-Identifier": `bub_gb_${id}`,


### PR DESCRIPTION
Fixes: [T348186](https://phabricator.wikimedia.org/T348186)

## Proposed Changes
- Add Authors to Internet-Archive Metadata when uploading from Google Books


## Files Updated
- bull/google-books-queue/consumer.js -  Retrieved authors from volumeInfo and added it to the metadata.  authors returns an array from volumeInfo which means there could be multiple authors, so I joined and trimed the array such that multiple authors will appear as a single comma seperated string


## Checklist 
- [x] Coding Conventions are followed.
- [x] Comments are used for Documenting the Code.
- [x] Correct File Names are mentioned.

