### PR TITLE
Fixes:[T346388] Allow multi-lingual books to be uploaded to Internet Archive

### DIFF
--- a/bull/google-books-queue/consumer.js
+++ b/bull/google-books-queue/consumer.js
@@ -37,6 +37,13 @@ GoogleBooksQueue.process((job, done) => {
     pageCount,
     infoLink,
   } = volumeInfo;
+  var isValidEnglishChar = /^[a-zA-Z0-9!@#$%^&*()_+{}\[\]:;<>,.?~\\/-\s]+$/;
+  const validEnglishTitle = isValidEnglishChar.test(title)
+    ? title
+    : "non english characters";
+  const validEnglishPublisher = isValidEnglishChar.test(publisher)
+    ? publisher
+    : "non english characters";
   const { accessViewStatus } = accessInfo;
   const bucketTitle = job.data.IAIdentifier;
   const IAuri = `http://s3.us.archive.org/${bucketTitle}/${bucketTitle}.pdf`;
@@ -59,13 +66,13 @@ GoogleBooksQueue.process((job, done) => {
           "X-Amz-Auto-Make-Bucket": "1",
           "X-Archive-Meta-Collection": "opensource",
           "X-Archive-Ignore-Preexisting-Bucket": 1,
-          "X-archive-meta-title": title.trim(),
+          "X-archive-meta-title": validEnglishTitle.trim(),
           "X-archive-meta-date": publishedDate.trim(),
           "X-archive-meta-language": language.trim(),
           "X-archive-meta-mediatype": "texts",
           "X-archive-meta-licenseurl":
             "https://creativecommons.org/publicdomain/mark/1.0/",
-          "X-archive-meta-publisher": publisher.trim(),
+          "X-archive-meta-publisher": validEnglishPublisher.trim(),
           "X-archive-meta-rights": accessViewStatus.trim(),
           "X-archive-meta-Google-id": id,
           "X-archive-meta-Identifier": `bub_gb_${id}`,

--- a/components/Books.js
+++ b/components/Books.js
@@ -445,7 +445,8 @@ class Books extends React.Component {
                   <button className="cdx-button cdx-button--action-progressive cdx-button--weight-primary">
                     Submit
                   </button>
-                  {this.state.isDuplicate === true && (
+                  {this.state.isDuplicate === true ||
+                  this.state.isEnglish === false ? (
                     <button
                       onClick={this.onResetButtonClicked}
                       style={{ marginLeft: 40 }}
@@ -453,7 +454,7 @@ class Books extends React.Component {
                     >
                       Reset
                     </button>
-                  )}
+                  ) : null}
                 </div>
               </div>
             )}

--- a/components/Books.js
+++ b/components/Books.js
@@ -18,6 +18,7 @@ class Books extends React.Component {
       show: true,
       loader: false,
       isDuplicate: false,
+      isEnglish: true,
       IATitle: "",
       IAIdentifier: "",
       inputDisabled: false,
@@ -34,6 +35,7 @@ class Books extends React.Component {
       option: event.target.value,
       bookid: "",
       isDuplicate: false,
+      isEnglish: true,
       IATitle: "",
       IAIdentifier: "",
       inputDisabled: false,
@@ -95,6 +97,7 @@ class Books extends React.Component {
   onResetButtonClicked = () => {
     this.setState({
       isDuplicate: false,
+      isEnglish: true,
       inputDisabled: false,
       IATitle: "",
       IAIdentifier: "",
@@ -202,9 +205,11 @@ class Books extends React.Component {
     this.setState({
       loader: true,
       isDuplicate: false,
+      isEnglish: true,
     });
 
     let url = "";
+    var isValidEnglishChar = /^[a-zA-Z0-9!@#$%^&*()_+{}\[\]:;<>,.?~\\/-\s]+$/;
     switch (this.state.option) {
       case "gb":
         url = `${host}/check?bookid=${this.state.bookid}&option=${
@@ -221,6 +226,12 @@ class Books extends React.Component {
               this.setState({
                 isDuplicate: true,
                 IATitle: response.titleInIA,
+                inputDisabled: true,
+              });
+            } else if (!isValidEnglishChar.test(response.IAIdentifier)) {
+              this.setState({
+                isEnglish: false,
+                IATitle: response.IAIdentifier,
                 inputDisabled: true,
               });
             } else {
@@ -314,6 +325,12 @@ class Books extends React.Component {
                   IATitle: response.titleInIA,
                   inputDisabled: true,
                 });
+              } else if (!isValidEnglishChar.test(response.IAIdentifier)) {
+                this.setState({
+                  isEnglish: false,
+                  IATitle: response.IAIdentifier,
+                  inputDisabled: true,
+                });
               } else {
                 if (response.error) Swal("Error!", response.message, "error");
                 else Swal("Voila!", response.message, "success");
@@ -342,6 +359,12 @@ class Books extends React.Component {
               this.setState({
                 isDuplicate: true,
                 IATitle: response.titleInIA,
+                inputDisabled: true,
+              });
+            } else if (!isValidEnglishChar.test(response.IAIdentifier)) {
+              this.setState({
+                isEnglish: false,
+                IATitle: response.IAIdentifier,
                 inputDisabled: true,
               });
             } else {
@@ -411,6 +434,38 @@ class Books extends React.Component {
                 </div>
               </div>
             ) : null}
+            {!this.state.isEnglish ? (
+              <div
+                class="cdx-message cdx-message--block cdx-message--warning"
+                aria-live="polite"
+                style={{ marginTop: "20px", display: "inline-block" }}
+              >
+                <span class="cdx-message__icon"></span>
+                <div class="cdx-message__content">
+                  The file you wish to upload has a non-english identifier -
+                  {this.state.IATitle} which may cause problems when uploading
+                  to internet archive. Please enter a valid English identifier
+                  to proceed.
+                  <div className="cdx-text-input input-group">
+                    <span className="input-group-addon helper" id="bid">
+                      https://archive.org/details/
+                    </span>
+                    <input
+                      className="cdx-text-input__input"
+                      type="text"
+                      id="IAIdentifier"
+                      name="IAIdentifier"
+                      onChange={(event) =>
+                        this.setState({ IAIdentifier: event.target.value })
+                      }
+                      required
+                      placeholder="Enter a valid English Identifier"
+                    />
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
             {session && (
               <div>
                 <div style={{ marginTop: 20, marginRight: 20 }}>

--- a/components/Books.js
+++ b/components/Books.js
@@ -3,6 +3,7 @@ import Swal from "sweetalert2";
 import { host } from "../utils/constants";
 import { withSession } from "../hooks/withSession";
 import { signIn } from "next-auth/react";
+import ChangeIdentifier from "./ChangeIdentifier";
 
 class Books extends React.Component {
   /**
@@ -402,68 +403,40 @@ class Books extends React.Component {
               {this.renderContent(this.state.option)}
             </div>
             {this.state.isDuplicate ? (
-              <div
-                class="cdx-message cdx-message--block cdx-message--warning"
-                aria-live="polite"
-                style={{ marginTop: "20px", display: "inline-block" }}
-              >
-                <span class="cdx-message__icon"></span>
-                <div class="cdx-message__content">
-                  A file with this identifier{" "}
-                  <a href={`https://archive.org/details/${this.state.IATitle}`}>
-                    (https://archive.org/{this.state.IATitle})
-                  </a>{" "}
-                  already exists at Internet Archive. Please enter a different
-                  identifier to proceed.
-                  <div className="cdx-text-input input-group">
-                    <span className="input-group-addon helper" id="bid">
-                      https://archive.org/details/
-                    </span>
-                    <input
-                      className="cdx-text-input__input"
-                      type="text"
-                      id="IAIdentifier"
-                      name="IAIdentifier"
-                      onChange={(event) =>
-                        this.setState({ IAIdentifier: event.target.value })
-                      }
-                      required
-                      placeholder="Enter unique file identifier"
-                    />
-                  </div>
-                </div>
-              </div>
+              <ChangeIdentifier
+                description={
+                  <>
+                    A file with this identifier{" "}
+                    <a
+                      href={`https://archive.org/details/${this.state.IATitle}`}
+                    >
+                      (https://archive.org/{this.state.IATitle})
+                    </a>{" "}
+                    already exists at Internet Archive. Please enter a different
+                    identifier to proceed.
+                  </>
+                }
+                inputPlaceholder="Enter unique file identifier"
+                onIdentifierChange={(event) =>
+                  this.setState({ IAIdentifier: event.target.value })
+                }
+              />
             ) : null}
             {!this.state.isEnglish ? (
-              <div
-                class="cdx-message cdx-message--block cdx-message--warning"
-                aria-live="polite"
-                style={{ marginTop: "20px", display: "inline-block" }}
-              >
-                <span class="cdx-message__icon"></span>
-                <div class="cdx-message__content">
-                  The file you wish to upload has a non-english identifier -
-                  {this.state.IATitle} which may cause problems when uploading
-                  to internet archive. Please enter a valid English identifier
-                  to proceed.
-                  <div className="cdx-text-input input-group">
-                    <span className="input-group-addon helper" id="bid">
-                      https://archive.org/details/
-                    </span>
-                    <input
-                      className="cdx-text-input__input"
-                      type="text"
-                      id="IAIdentifier"
-                      name="IAIdentifier"
-                      onChange={(event) =>
-                        this.setState({ IAIdentifier: event.target.value })
-                      }
-                      required
-                      placeholder="Enter a valid English Identifier"
-                    />
-                  </div>
-                </div>
-              </div>
+              <ChangeIdentifier
+                description={
+                  <>
+                    The file you wish to upload has a non-english identifier -
+                    {this.state.IATitle} which may cause problems when uploading
+                    to internet archive. Please enter a valid English identifier
+                    to proceed.
+                  </>
+                }
+                inputPlaceholder="Enter a valid English Identifier"
+                onIdentifierChange={(event) =>
+                  this.setState({ IAIdentifier: event.target.value })
+                }
+              />
             ) : null}
 
             {session && (

--- a/components/ChangeIdentifier.js
+++ b/components/ChangeIdentifier.js
@@ -1,0 +1,34 @@
+const ChangeIdentifier = ({
+  description,
+  inputPlaceholder,
+  onIdentifierChange,
+}) => {
+  return (
+    <div
+      className="cdx-message cdx-message--block cdx-message--warning"
+      aria-live="polite"
+      style={{ marginTop: "20px", display: "inline-block" }}
+    >
+      <span className="cdx-message__icon"></span>
+      <div className="cdx-message__content">
+        {description}
+        <div className="cdx-text-input input-group">
+          <span className="input-group-addon helper" id="bid">
+            https://archive.org/details/
+          </span>
+          <input
+            className="cdx-text-input__input"
+            type="text"
+            id="IAIdentifier"
+            name="IAIdentifier"
+            onChange={onIdentifierChange}
+            required
+            placeholder={inputPlaceholder}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChangeIdentifier;


### PR DESCRIPTION
Fixes: [T346388](https://phabricator.wikimedia.org/T346388)

## Proposed Changes
- Prompt user to enter a new valid English Identifier if the previous identifier is non-english 
- Enable Books with non-English titles to be uploaded to internet Archive


## Files Created/Updated

- components/ChangeIdentifier.js - Extract the component used in handling duplicate identifier into a new component called ChangeIdentifier to enable efficient reuse
- components/Books.js - add a conditional that checks if the initial generated identifier has English Characters.  If it has non-English characters , reuse the new ChangeIdentifier component and prompt the user to enter a new valid English Identifier
- bull/google-books-queue/consumer.js - I found that the meta data title and publisher values must also be English to be accepted by internet archive. So I implemented a check that validates the title and publisher values to be English Characters. If they are English their values are used, if they are not a string ('non english characters') is used


## Current Look
![Screenshot (22)](https://github.com/coderwassananmol/BUB2/assets/65835404/688634a3-d9ea-43fc-9198-19b5ee93dbd1)



## Checklist 
- [x] Coding Conventions are followed.
- [x] Comments are used for Documenting the Code.
- [x] Correct File Names are mentioned.
