### PR TITLE
Fixes: [T348188] For PDL, download and stream the PDF if available

### DIFF
--- a/bull/pdl-queue/consumer.js
+++ b/bull/pdl-queue/consumer.js
@@ -121,7 +121,7 @@ async function uploadZipToIA(zip, metadata, byteLength, email, job) {
 }
 
 async function uploadPdfToIA(uri, metadata, email, job) {
-  const requestURI = request(job.data.uri);
+  const requestURI = request(uri);
   const bucketTitle = metadata.IAIdentifier;
   const IAuri = `http://s3.us.archive.org/${bucketTitle}/${bucketTitle}.pdf`;
   let headers = setHeaders(

--- a/bull/pdl-queue/consumer.js
+++ b/bull/pdl-queue/consumer.js
@@ -65,10 +65,7 @@ function setHeaders(metadata, byteLength, title, contentType) {
   headers[
     "Authorization"
   ] = `LOW ${process.env.access_key}:${process.env.secret_key}`;
-  headers["Content-type"] =
-    contentType === "zip"
-      ? "application/zip"
-      : "application/pdf; charset=utf-8";
+  headers["Content-type"] = contentType;
   headers["Content-length"] = byteLength;
   headers["X-Amz-Auto-Make-Bucket"] = 1;
   headers["X-Archive-meta-collection"] = "opensource";
@@ -93,7 +90,12 @@ async function uploadZipToIA(zip, metadata, byteLength, email, job) {
   const bucketTitle = metadata.IAIdentifier;
   const IAuri = `http://s3.us.archive.org/${bucketTitle}/${bucketTitle}_images.zip`;
   metadata = _.omit(metadata, "coverImage");
-  let headers = setHeaders(metadata, byteLength, metadata.title, zip);
+  let headers = setHeaders(
+    metadata,
+    byteLength,
+    metadata.title,
+    job.data.details.contentType
+  );
   await zip.generateNodeStream({ type: "nodebuffer", streamFiles: true }).pipe(
     request(
       {
@@ -122,7 +124,12 @@ async function uploadPdfToIA(uri, metadata, email, job) {
   const requestURI = request(job.data.uri);
   const bucketTitle = metadata.IAIdentifier;
   const IAuri = `http://s3.us.archive.org/${bucketTitle}/${bucketTitle}.pdf`;
-  let headers = setHeaders(metadata, responseSize, metadata.title, pdf);
+  let headers = setHeaders(
+    metadata,
+    responseSize,
+    metadata.title,
+    job.data.details.contentType
+  );
   requestURI.pipe(
     request(
       {

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -177,7 +177,7 @@ module.exports = {
     //if download option is available, then add download uri to metadata
     if (downloadLink.length) {
       const downloadHref = downloadLink.attr("href");
-      PNdetails.uri = downloadHref;
+      PNdetails.uri = `http://www.panjabdigilib.org/webuser/searches/${downloadHref}`;
     }
 
     delete PNdetails[""];

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -106,6 +106,7 @@ module.exports = {
     const keys = $(".ubhypers");
     const values = $(".dhypers");
     const downloadLink = $("#downloadpdf a");
+    let contentType = "zip";
 
     function addOtherMetaData(limit, keys, values, PNdetails) {
       let value;
@@ -176,9 +177,11 @@ module.exports = {
 
     //if download option is available, then add download uri to metadata
     if (downloadLink.length) {
+      contentType = "pdf";
       const downloadHref = downloadLink.attr("href");
       PNdetails.uri = `http://www.panjabdigilib.org/webuser/searches/${downloadHref}`;
     }
+    PNdetails.contentType = contentType;
 
     delete PNdetails[""];
 

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -105,6 +105,7 @@ module.exports = {
     let PNdetails = {};
     const keys = $(".ubhypers");
     const values = $(".dhypers");
+    const downloadLink = $("#downloadpdf a");
 
     function addOtherMetaData(limit, keys, values, PNdetails) {
       let value;
@@ -172,6 +173,12 @@ module.exports = {
     ).attr("src");
     src = src.match(/pdl.*/gm);
     PNdetails.coverImage = `http://panjabdigilib.org/${src}`;
+
+    //if download option is available, then add download uri to metadata
+    if (downloadLink.length) {
+      const downloadHref = downloadLink.attr("href");
+      PNdetails.uri = downloadHref;
+    }
 
     delete PNdetails[""];
 


### PR DESCRIPTION
Fixes: [T348188](https://phabricator.wikimedia.org/T348188)

### Changes Made

- Check if there is direct pdf download option available for books/newsletters/magazines.
- If yes, enable download and automate the upload without parsing each image separately.

### Files Updated

- utils/helper.js - Implement a check to find if direct pdf download option is available for the pdl resource, and add it to metadata if available.
- bull/pdl-queue/consumer.js - Create a new function to download the pdf and automate its upload without parsing each image separately. After this I added suitable content type headers by adding a validation to check for pdf or zip.