### PR TITLE
Fixes:[T348192] Add max character limit while creating identifier in Internet Archive and remove some special characters

### DIFF
--- a/components/Books.js
+++ b/components/Books.js
@@ -3,6 +3,7 @@ import Swal from "sweetalert2";
 import { host } from "../utils/constants";
 import { withSession } from "../hooks/withSession";
 import { signIn } from "next-auth/react";
+import ChangeIdentifier from "./ChangeIdentifier";
 
 class Books extends React.Component {
   /**
@@ -18,6 +19,7 @@ class Books extends React.Component {
       show: true,
       loader: false,
       isDuplicate: false,
+      isValidIdentifier: true,
       IATitle: "",
       IAIdentifier: "",
       inputDisabled: false,
@@ -34,6 +36,7 @@ class Books extends React.Component {
       option: event.target.value,
       bookid: "",
       isDuplicate: false,
+      isValidIdentifier: true,
       IATitle: "",
       IAIdentifier: "",
       inputDisabled: false,
@@ -95,6 +98,7 @@ class Books extends React.Component {
   onResetButtonClicked = () => {
     this.setState({
       isDuplicate: false,
+      isValidIdentifier: true,
       inputDisabled: false,
       IATitle: "",
       IAIdentifier: "",
@@ -202,9 +206,11 @@ class Books extends React.Component {
     this.setState({
       loader: true,
       isDuplicate: false,
+      isValidIdentifier: true,
     });
 
     let url = "";
+    const isAlphanumericLess50 = /^(?=.*[a-zA-Z])(?=.*[0-9])[a-zA-Z0-9]{1,50}$/;
     switch (this.state.option) {
       case "gb":
         url = `${host}/check?bookid=${this.state.bookid}&option=${
@@ -221,6 +227,12 @@ class Books extends React.Component {
               this.setState({
                 isDuplicate: true,
                 IATitle: response.titleInIA,
+                inputDisabled: true,
+              });
+            } else if (!isAlphanumericLess50.test(response.IAIdentifier)) {
+              this.setState({
+                isValidIdentifier: false,
+                IATitle: response.IAIdentifier,
                 inputDisabled: true,
               });
             } else {
@@ -314,6 +326,12 @@ class Books extends React.Component {
                   IATitle: response.titleInIA,
                   inputDisabled: true,
                 });
+              } else if (!isAlphanumericLess50.test(response.IAIdentifier)) {
+                this.setState({
+                  isValidIdentifier: false,
+                  IATitle: response.IAIdentifier,
+                  inputDisabled: true,
+                });
               } else {
                 if (response.error) Swal("Error!", response.message, "error");
                 else Swal("Voila!", response.message, "success");
@@ -342,6 +360,12 @@ class Books extends React.Component {
               this.setState({
                 isDuplicate: true,
                 IATitle: response.titleInIA,
+                inputDisabled: true,
+              });
+            } else if (!isAlphanumericLess50.test(response.IAIdentifier)) {
+              this.setState({
+                isValidIdentifier: false,
+                IATitle: response.IAIdentifier,
                 inputDisabled: true,
               });
             } else {
@@ -379,45 +403,51 @@ class Books extends React.Component {
               {this.renderContent(this.state.option)}
             </div>
             {this.state.isDuplicate ? (
-              <div
-                class="cdx-message cdx-message--block cdx-message--warning"
-                aria-live="polite"
-                style={{ marginTop: "20px", display: "inline-block" }}
-              >
-                <span class="cdx-message__icon"></span>
-                <div class="cdx-message__content">
-                  A file with this identifier{" "}
-                  <a href={`https://archive.org/details/${this.state.IATitle}`}>
-                    (https://archive.org/{this.state.IATitle})
-                  </a>{" "}
-                  already exists at Internet Archive. Please enter a different
-                  identifier to proceed.
-                  <div className="cdx-text-input input-group">
-                    <span className="input-group-addon helper" id="bid">
-                      https://archive.org/details/
-                    </span>
-                    <input
-                      className="cdx-text-input__input"
-                      type="text"
-                      id="IAIdentifier"
-                      name="IAIdentifier"
-                      onChange={(event) =>
-                        this.setState({ IAIdentifier: event.target.value })
-                      }
-                      required
-                      placeholder="Enter unique file identifier"
-                    />
-                  </div>
-                </div>
-              </div>
+              <ChangeIdentifier
+                description={
+                  <>
+                    A file with this identifier{" "}
+                    <a
+                      href={`https://archive.org/details/${this.state.IATitle}`}
+                    >
+                      (https://archive.org/{this.state.IATitle})
+                    </a>{" "}
+                    already exists at Internet Archive. Please enter a different
+                    identifier to proceed.
+                  </>
+                }
+                inputPlaceholder="Enter unique file identifier"
+                onIdentifierChange={(event) =>
+                  this.setState({ IAIdentifier: event.target.value })
+                }
+              />
             ) : null}
+
+            {this.state.isValidIdentifier === false ? (
+              <ChangeIdentifier
+                description={
+                  <>
+                    The file you wish to upload has an identifier -{" "}
+                    {this.state.IATitle} which is greater than 50 characters
+                    and/or is not Alphanumeric. Please enter a valid Identifier
+                    that is Alphanumeric and less than 50 characters
+                  </>
+                }
+                inputPlaceholder="Enter a valid Identifier that is less than 50 characters and Alphanumeric"
+                onIdentifierChange={(event) =>
+                  this.setState({ IAIdentifier: event.target.value })
+                }
+              />
+            ) : null}
+
             {session && (
               <div>
                 <div style={{ marginTop: 20, marginRight: 20 }}>
                   <button className="cdx-button cdx-button--action-progressive cdx-button--weight-primary">
                     Submit
                   </button>
-                  {this.state.isDuplicate === true && (
+                  {this.state.isDuplicate === true ||
+                  this.state.isValidIdentifier === false ? (
                     <button
                       onClick={this.onResetButtonClicked}
                       style={{ marginLeft: 40 }}
@@ -425,7 +455,7 @@ class Books extends React.Component {
                     >
                       Reset
                     </button>
-                  )}
+                  ) : null}
                 </div>
               </div>
             )}

--- a/components/Books.js
+++ b/components/Books.js
@@ -427,10 +427,11 @@ class Books extends React.Component {
               <ChangeIdentifier
                 description={
                   <>
-                    The file you wish to upload has an identifier -{" "}
-                    {this.state.IATitle} which is greater than 50 characters
-                    and/or is not Alphanumeric. Please enter a valid Identifier
-                    that is Alphanumeric and less than 50 characters
+                    The file you want to upload with title -{" "}
+                    {this.state.IATitle} either contains special characters or
+                    exceeds 50 characters in length. Please provide an
+                    identifier that consists only of letters (A-Z) and numbers
+                    (0-9).
                   </>
                 }
                 inputPlaceholder="Enter a valid Identifier that is less than 50 characters and Alphanumeric"

--- a/components/ChangeIdentifier.js
+++ b/components/ChangeIdentifier.js
@@ -1,0 +1,34 @@
+const ChangeIdentifier = ({
+  description,
+  inputPlaceholder,
+  onIdentifierChange,
+}) => {
+  return (
+    <div
+      className="cdx-message cdx-message--block cdx-message--warning"
+      aria-live="polite"
+      style={{ marginTop: "20px", display: "inline-block" }}
+    >
+      <span className="cdx-message__icon"></span>
+      <div className="cdx-message__content">
+        {description}
+        <div className="cdx-text-input input-group">
+          <span className="input-group-addon helper" id="bid">
+            https://archive.org/details/
+          </span>
+          <input
+            className="cdx-text-input__input"
+            type="text"
+            id="IAIdentifier"
+            name="IAIdentifier"
+            onChange={onIdentifierChange}
+            required
+            placeholder={inputPlaceholder}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ChangeIdentifier;


### PR DESCRIPTION
Fixes: [T348192](https://phabricator.wikimedia.org/T348192)

## Proposed Changes
- Validates if generated identifier is less than 50 characters and alphanumeric
- Prompts user to enter a new identifier if validation fails


## Files Created/Updated

- components/ChangeIdentifier.js - Extract the component used in handling duplicate identifier into a new component called ChangeIdentifier to enable efficient reuse
- components/Books.js - add a conditional that checks if the initial generated identifier is Alphanumeric and not more than 50 characters.  If it fails the validation , reuse the new ChangeIdentifier component and prompt the user to enter a new identifier that meets the requirements.



## Current Look

![Screenshot (27)](https://github.com/coderwassananmol/BUB2/assets/65835404/fe416b5b-bfc2-486c-ad6b-1110091cd7a2)




## Checklist 
- [x] Coding Conventions are followed.
- [x] Comments are used for Documenting the Code.
- [x] Correct File Names are mentioned.