### PR TITLE
Fixes:[T348188] For PDL, download and stream the PDF if available

### DIFF
--- a/bull/pdl-queue/consumer.js
+++ b/bull/pdl-queue/consumer.js
@@ -76,7 +76,7 @@ async function getPdfAndBytelength(pdfUrl, job) {
       new Headers({
         "Content-Type": "application/pdf",
       }),
-      "pdf"
+      "file"
     );
     if (response.status === 200) {
       job.progress(30);

--- a/bull/pdl-queue/consumer.js
+++ b/bull/pdl-queue/consumer.js
@@ -106,7 +106,7 @@ function setHeaders(metadata, byteLength, title, contentType) {
   headers[
     "Authorization"
   ] = `LOW ${process.env.access_key}:${process.env.secret_key}`;
-  headers["Content-type"] = "application/zip";
+  headers["Content-type"] = `application/${contentType}`;
   headers["Content-length"] = byteLength;
   headers["X-Amz-Auto-Make-Bucket"] = 1;
   headers["X-Archive-meta-collection"] = "opensource";

--- a/bull/pdl-queue/consumer.js
+++ b/bull/pdl-queue/consumer.js
@@ -87,12 +87,16 @@ async function getPdfAndBytelength(pdfUrl, job) {
         byteLength: buffer.byteLength,
       };
     } else {
-      throw new Error(
-        `Failed to download PDF. Status Code: ${response.status} `
-      );
+      logger.log({
+        level: "error",
+        message: `Failure PDL: Failed to download PDF. Status Code: ${response.status}`,
+      });
     }
   } catch (error) {
-    console.error("Error:", error);
+    logger.log({
+      level: "error",
+      message: `Failure PDL: ${error}`,
+    });
     return null;
   }
 }

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -114,6 +114,8 @@ module.exports = {
     const keys = $(".ubhypers");
     const values = $(".dhypers");
     const downloadPdfLink = $("#downloadpdf a")[0]?.attribs.href;
+    let pagesLabel = $(".ubhypers:contains('Pages')");
+    let pagesValue = pagesLabel.parent().next().find(".dhypers").text();
     let contentType = "zip";
     function addOtherMetaData(limit, keys, values, PNdetails) {
       let value;
@@ -187,8 +189,8 @@ module.exports = {
       PNdetails.pdfUrl = `http://www.panjabdigilib.org/webuser/searches/${downloadPdfLink}`;
     }
     PNdetails.contentType = contentType;
+    PNdetails.Pages = pagesValue;
     delete PNdetails[""];
-
     return PNdetails;
   },
 

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -40,7 +40,7 @@ module.exports = {
           if (res.status === 404) {
             return 404;
           } else {
-            const result = contentType === "pdf" ? res : res.json();
+            const result = contentType === "file" ? res : res.json();
             return result;
           }
         },

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -25,7 +25,12 @@ module.exports = {
     return title.replace(/[ \(\)\[\],:]/g, "");
   },
 
-  customFetch: async (URI, method = "GET", headers = new Headers()) => {
+  customFetch: async (
+    URI,
+    method = "GET",
+    headers = new Headers(),
+    contentType = "other"
+  ) => {
     return fetch(URI, {
       method: method,
       headers: headers,
@@ -34,7 +39,10 @@ module.exports = {
         (res) => {
           if (res.status === 404) {
             return 404;
-          } else return res.json();
+          } else {
+            const result = contentType === "pdf" ? res : res.json();
+            return result;
+          }
         },
         (err) => {
           logger.log({
@@ -105,7 +113,8 @@ module.exports = {
     let PNdetails = {};
     const keys = $(".ubhypers");
     const values = $(".dhypers");
-
+    const downloadPdfLink = $("#downloadpdf a")[0]?.attribs.href;
+    let contentType = "zip";
     function addOtherMetaData(limit, keys, values, PNdetails) {
       let value;
       for (let i = 0; i < values.length; i++) {
@@ -173,6 +182,11 @@ module.exports = {
     src = src.match(/pdl.*/gm);
     PNdetails.coverImage = `http://panjabdigilib.org/${src}`;
 
+    if (downloadPdfLink?.length) {
+      contentType = "pdf";
+      PNdetails.pdfUrl = `http://www.panjabdigilib.org/webuser/searches/${downloadPdfLink}`;
+    }
+    PNdetails.contentType = contentType;
     delete PNdetails[""];
 
     return PNdetails;


### PR DESCRIPTION
Fixes: [T348188](https://phabricator.wikimedia.org/T348188)

## Proposed Changes
- For PDL - Check if PDF is available then download and upload the PDF directly without parsing each image separately.

## Files Created/Updated

- utils/helper.js - check if PDF link is available and return the pdfUrl download link if true
- bull/pdl-queue/consumer.js -  create a function getPdfAndBytelength that downloads the PDF and returns the PDF file and the PDF size. Create a function uploadPdfToIA that uploads PDF and metadata to Internet Archive. Add a conditional that executes getPdfAndBytelength or getZipAndBytelength depending on if pdfUrl is returned



## Checklist 
- [x] Coding Conventions are followed.
- [x] Comments are used for Documenting the Code.
- [x] Correct File Names are mentioned.

