### PR TITLE
Feat: #T338267: Use API:EmailUser to send Emails to the users

### DIFF
--- a/components/Books.js
+++ b/components/Books.js
@@ -15,6 +15,7 @@ const Books = () => {
   const [IATitle, setIATitle] = useState("");
   const [IAIdentifier, setIAIdentifier] = useState("");
   const [inputDisabled, setInputDisabled] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
 
   const handleChange = (event) => {
     setOption(event.target.value);
@@ -114,7 +115,7 @@ const Books = () => {
     return urlPattren.test(urlString);
   };
 
-  const onSubmit = (event) => {
+  const onSubmit = async (event) => {
     event.preventDefault();
 
     if (!session.user.name || session.user.name === "") {
@@ -244,6 +245,25 @@ const Books = () => {
           });
         break;
     }
+
+    if (isChecked) {
+      const response = await fetch("/submit", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: email,
+          subject: "Upload Status",
+          text: "Your upload was successful!",
+        }),
+      });
+
+      if (!response.ok) {
+        console.error("Failed to send email:", response.statusText);
+      }
+      setEmail(event.target.email.value);
+    }
   };
 
   return (
@@ -267,6 +287,7 @@ const Books = () => {
               <option value="trove">Trove Digital Library</option>
             </select>
           </div>
+
           <div className="section">{renderContent(option)}</div>
           {isDuplicate ? (
             <ChangeIdentifier
@@ -324,6 +345,32 @@ const Books = () => {
           )}
           {!session && (
             <div style={{ marginTop: 20 }}>
+              {/* email check box */}
+              <div className="cdx-label">
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={isChecked}
+                    onChange={(event) => setIsChecked(event.target.checked)}
+                    style={{ marginRight: "10px" }}
+                  />
+                  Notify updates via e-mail
+                </label>
+                {isChecked && (
+                  <span
+                    id="cdx-description-css-1"
+                    className="cdx-label__description"
+                  >
+                    <p>
+                      <span className="cdx-css-icon--info-icon"></span>
+                      &nbsp; BUB2 will send an email to your email ID associated
+                      with your Wikimedia account regarding the success or
+                      failure of the upload. If no email is added to the
+                      account, email will not be sent.
+                    </p>
+                  </span>
+                )}
+              </div>
               <div className="cdx-label">
                 <span className="cdx-label__description">
                   Upload restricted. Login with Wikimedia Account to continue.

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const cors = require("cors");
 const open = require("open");
 const compression = require("compression");
 require("dotenv").config();
+const nodemailer = require("nodemailer");
 const dev = process.env.NODE_ENV !== "production";
 const PORT = process.env.PORT || 5000;
 const GB_KEY = process.env.GB_KEY;
@@ -66,6 +67,40 @@ app
         extended: true,
       })
     );
+
+    //SendEmail function
+    const SendEmail = (recipient, content) => {
+      let transporter = nodemailer.createTransport({
+        service: process.env.EMAIL_SERVICE,
+        auth: {
+          user: process.env.EMAIL_USER,
+          pass: process.env.EMAIL_PASS,
+        },
+      });
+
+      let mailOptions = {
+        from: process.env.EMAIL_USER,
+        to: recipient,
+        subject: subject,
+        text: text,
+      };
+
+      transporter.sendMail(mailOptions, function (error, info) {
+        if (error) {
+          console.log(error);
+        } else {
+          console.log("Email sent: " + info.response);
+        }
+      });
+    };
+
+    server.post("/submit", async (req, res) => {
+      SendEmail(
+        req.body.email,
+        "Form Submitted",
+        "Your form has been submitted successfully."
+      );
+    });
 
     //Parse application/json
     server.use(bodyParser.json());

--- a/styles/global.less
+++ b/styles/global.less
@@ -24,3 +24,7 @@
 	.cdx-mixin-css-icon(@cdx-icon-expand, @param-is-button-icon: true, @param-size-icon: @size-icon-medium);
 	margin-left: 5px;
 }
+
+.cdx-css-icon--info-icon {
+  .cdx-mixin-css-icon(@cdx-icon-info-filled);
+}


### PR DESCRIPTION
The changes I've made include:

# Collecting User Consent:
I've added a checkbox to the form that allows users to opt-in to email notifications. The checkbox is labeled "Notify updates via email", and there's an info icon next to it that provides more details when clicked.

# Collecting User Email:
The user's email ID is been collected when they authorize with their Wikimedia account. This email ID is then used to send the email notifications.

# Sending the Email:
 I've set up an SMTP server using Nodemailer. When the user submits the form and the checkbox is checked, an email is sent to the user.
Issue link: https://phabricator.wikimedia.org/T338267