### PR TITLE
Fixes:[T349567] QueueTable Footer Pagination inconsistent style

### DIFF
--- a/components/QueueTable.js
+++ b/components/QueueTable.js
@@ -225,19 +225,19 @@ const ShowUploadQueue = (props) => {
         </TableContainer>
         <TablePagination
           rowsPerPageOptions={[10, 25, 100]}
-          component="div"
           SelectProps={styles.selectIcon}
+          count={rows.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
           labelRowsPerPage={<div style={styles.toolbar}>Rows per page</div>}
           labelDisplayedRows={({ from, to, count }) => (
             <div style={styles.toolbar}>
               {`${from}–${to} of ${count !== -1 ? count : `more than ${to}`}`}
             </div>
           )}
-          count={rows.length}
-          rowsPerPage={rowsPerPage}
-          page={page}
-          onPageChange={handleChangePage}
-          onRowsPerPageChange={handleChangeRowsPerPage}
+          sx={{ display: "flex", justifyContent: "end" }}
         />
       </Paper>
       <Backdrop sx={styles.backdrop} open={open} onClick={handleClose}>


### PR DESCRIPTION
Fixes: [T349567](https://phabricator.wikimedia.org/T349567)

## Proposed Changes
- The QueueTable pagination style should remain the same after tab refresh


## Files Created/Updated

- components/QueueTable.js  - Persist pagination style on refresh

## Checklist 
- [x] Coding Conventions are followed.
- [x] Comments are used for Documenting the Code.
- [x] Correct File Names are mentioned.
