### PR TITLE
Fixes:[T346386] Integrate Wikimedia Ecosystem within BUB2 tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "less-loader": "^11.1.3",
     "loaders.css": "^0.1.2",
     "lodash": "^4.17.20",
+    "mwn": "^2.0.1",
     "next": "^12.2.5",
     "next-auth": "^4.15.1",
     "next-with-less": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "nodemailer": "^6.7.8",
     "nprogress": "^0.2.0",
     "open": "^7.0.3",
+    "pdf-lib": "^1.17.1",
     "pdfkit": "^0.9.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/polling.js
+++ b/polling.js
@@ -1,0 +1,472 @@
+const { customFetch } = require("./utils/helper");
+const config = require("./utils/bullconfig");
+const { Mwn } = require("mwn");
+const winston = require("winston");
+const logger = winston.loggers.get("defaultLogger");
+
+const IACountQueue = config.getNewQueue("ia-current-item");
+const IACountQueueJobId = "currentIAItemIndex";
+const IAAdvancedSearchURL = `https://archive.org/advancedsearch.php?q=bub.wikimedia&fl%5B%5D=identifier&sort%5B%5D&sort%5B%5D=addeddate+desc&rows=400&page=1&output=json&save=yes`;
+const IAMetaDataBaseUrl = `https://archive.org/metadata`;
+
+/**
+ * The function `getIAMetadataAndDownloadUrl` makes a query to IA Advanced Search. The query returns an array of all items (identifiers) uploaded by IA Member `bub.wikimedia`.
+ * Using the `count` variable stored on redis (via Bull) as its index it then selects and returns an item(`identifier`) from the array provided by the IA Advanced Search query.
+ * Using the `identifier` it retrieves the corresponding metadata from IA.
+ * @returns The function `getIAMetadataAndDownloadUrl` returns an object that contains the metadata of selected IA item and the download url of its pdf or zip file
+ * @docs IA Advanced Search: https://archive.org/advancedsearch.php
+ * IA Metadata API: https://archive.org/developers/md-read.html
+ */
+async function getIAMetadataAndDownloadUrl() {
+  const getIACountQueue = await IACountQueue.getJob(`${IACountQueueJobId}`);
+  const IACurrentIndex = getIACountQueue ? getIACountQueue.data.count : 0;
+  const IAbub_wikimediaItems = await customFetch(
+    `${IAAdvancedSearchURL}`,
+    "GET"
+  );
+  if (IAbub_wikimediaItems === 404) {
+    logger.log({
+      level: "info",
+      message: `Polling - getIAMetadataAndDownloadUrl: IA Advanced Search Failed`,
+    });
+    return 404;
+  } else {
+    const IACurrentIdentifier =
+      IAbub_wikimediaItems.response.docs[`${IACurrentIndex}`].identifier;
+    const IAMetaDataURL = `${IAMetaDataBaseUrl}/${IACurrentIdentifier}`;
+    const IAItemMetaData = await customFetch(`${IAMetaDataURL}`, "GET");
+    if (IAItemMetaData === 404) {
+      logger.log({
+        level: "error",
+        message: `Polling - getIAMetadataAndDownloadUrl: Failed to fetch ${IAMetaDataURL} metadata`,
+      });
+      return 404;
+    } else {
+      const IAPdfFileName = IAItemMetaData.files.find((item) =>
+        item.name.endsWith(".pdf")
+      );
+      const IATorrentFileName = IAItemMetaData.files.find((item) =>
+        item.name.endsWith(".zip")
+      );
+      const IADownloadFileName = IAPdfFileName
+        ? IAPdfFileName
+        : IATorrentFileName;
+      const IADownloadURL_PDF = `https://archive.org/download/${IACurrentIdentifier}/${IADownloadFileName.name}`;
+      return {
+        IAItemMetaData,
+        IADownloadURL_PDF,
+      };
+    }
+  }
+}
+
+/**
+ * The Wikimedia Commons API allows uploads directly from a URL.
+ * The function `uploadToCommons` uploads the file and metadata returned from `getIAMetadataAndDownloadUrl` to Wikimedia Commons using the Mwn toolforge package. After successful upload, it updates the `count` variable stored on redis (via Bull)
+ * @param IAItemMetaData  `IAItemMetaData` is an object that contains metadata information about an item from IA.
+ * @param IADownloadURL_PDF  The `IADownloadURL_PDF` parameter is the URL of the PDF/ZIP file
+ * that you want to upload to Wikimedia Commons. It should be a valid URL pointing to the location of the PDF/ZIP file.
+ * @returns The function `uploadToCommons` returns the Commons filename of the uploaded file if the upload is successful.
+ * @docs MWN TOOLFORGE PACKAGE - https://github.com/siddharthvp/mwn
+ * Wikimedia Commons Upload File - https://www.mediawiki.org/wiki/API:Upload#JavaScript_2
+ */
+async function uploadToCommons(IAItemMetaData, IADownloadURL_PDF) {
+  const bot = await Mwn.init({
+    apiUrl: "https://commons.wikimedia.org/w/api.php",
+    username: process.env.EMAIL_BOT_USERNAME,
+    password: process.env.EMAIL_BOT_PASSWORD,
+    userAgent: "bub2.toolforge ([[https://bub2.toolforge.org]])",
+    defaultParams: {
+      assert: "user",
+    },
+  });
+  const getIACountQueue = await IACountQueue.getJob(`${IACountQueueJobId}`);
+  const currentCount = getIACountQueue ? getIACountQueue.data.count : 0;
+
+  async function upload_file() {
+    try {
+      const IAItemPermission = IAItemMetaData.metadata.licenseurl
+        ? `CCO No Rights Reserved ${IAItemMetaData.metadata.licenseurl}`
+        : "CC0 No Rights Reserved. Provided at no cost and free to use https://archive.org/about/terms.php";
+
+      const res = await bot.uploadFromUrl(
+        IADownloadURL_PDF,
+        IAItemMetaData.metadata.title,
+        `{{Book
+|Author=${IAItemMetaData.metadata.author}
+|Title=${IAItemMetaData.metadata.title}
+|Description=${IAItemMetaData.metadata.description}
+|Language=${IAItemMetaData.metadata.language}
+|Publication Date=${IAItemMetaData.metadata.addeddate}
+|Source=${IAItemMetaData.metadata["identifier-access"]}
+|Publisher=${IAItemMetaData.metadata.publisher}
+|Permission=${IAItemPermission}
+|Other_fields_1={{Information field|name=Contributor|value=${IAItemMetaData.metadata.contributor}|name=Pages|value=${IAItemMetaData.metadata.pages}|name=Internet_Archive_Identifier|value=${IAItemMetaData.metadata.identifier}}}
+}}
+{{cc-zero}}
+[[Category:bub.wikimedia]]
+`
+      );
+      getIACountQueue?.remove();
+      IACountQueue.add(
+        {
+          count: currentCount + 1,
+        },
+        {
+          jobId: `${IACountQueueJobId}`,
+        }
+      );
+      logger.log({
+        level: "info",
+        message: `Polling - uploadToCommons: Upload of ${IADownloadURL_PDF} to commons successful`,
+      });
+      return res.filename;
+    } catch (error) {
+      logger.log({
+        level: "error",
+        message: `Polling - uploadToCommons: Failed to upload ${IADownloadURL_PDF} to commons: ${error}`,
+      });
+      return 404;
+    }
+  }
+  return await upload_file();
+}
+
+/**
+ * The function `uploadToWikidata` uploads the metadata initially uploaded to Commons by `uploadToCommons` to Wikidata using the Mwn toolforge package
+ * @param IAItemMetaData - IAItemMetaData is an object that contains metadata information about an item from IA.
+ * @param commonsItemFilename - The `commonsItemFilename` parameter is the filename of the item on
+ * Wikimedia Commons. It is used to set the label and file name properties in the Wikidata item.
+ * @returns The function `uploadToWikidata` returns the wikidataId of the newly created wikidata entity
+ * @docs MWN TOOLFORGE PACKAGE - https://github.com/siddharthvp/mwn
+ * Wikidata API - https://www.mediawiki.org/wiki/Wikibase/API
+ * Mapping for the labels/properties defined in `payload` - https://prop-explorer.toolforge.org/
+ */
+async function uploadToWikidata(IAItemMetaData, commonsItemFilename) {
+  const bot = await Mwn.init({
+    apiUrl: "https://www.wikidata.org/w/api.php",
+    username: process.env.EMAIL_BOT_USERNAME,
+    password: process.env.EMAIL_BOT_PASSWORD,
+    userAgent: "bub2.toolforge ([[https://bub2.toolforge.org]])",
+    defaultParams: {
+      assert: "user",
+    },
+  });
+  async function getCsrfToken() {
+    try {
+      const res = await bot.request({
+        action: "query",
+        meta: "tokens",
+        format: "json",
+      });
+
+      return await createEntity(res.query.tokens.csrftoken);
+    } catch (error) {
+      logger.log({
+        level: "error",
+        message: `Polling - getCsrfToken: Failed to fetch CSRF token: ${error}`,
+      });
+    }
+  }
+
+  async function createEntity(csrf_token) {
+    try {
+      const payload = {
+        labels: {
+          en: {
+            language: "en",
+            value: commonsItemFilename,
+          },
+        },
+        descriptions: {
+          en: {
+            language: "en",
+            value: IAItemMetaData.title,
+          },
+        },
+        claims: {
+          file_name: [
+            {
+              mainsnak: {
+                snaktype: "value",
+                property: "P18",
+                datavalue: {
+                  value: commonsItemFilename,
+                  type: "string",
+                },
+              },
+              type: "statement",
+              rank: "normal",
+            },
+          ],
+          file_url: [
+            {
+              mainsnak: {
+                snaktype: "value",
+                property: "P4765",
+                datavalue: {
+                  value: `https://commons.wikimedia.org/wiki/File:${commonsItemFilename}`,
+                  type: "string",
+                },
+              },
+              type: "statement",
+              rank: "normal",
+            },
+          ],
+          commons_category: [
+            {
+              mainsnak: {
+                snaktype: "value",
+                property: "P373",
+                datavalue: {
+                  value: "Bub.wikimedia",
+                  type: "string",
+                },
+              },
+              type: "statement",
+              rank: "normal",
+            },
+          ],
+          inventory_number: IAItemMetaData.bookid
+            ? [
+                {
+                  mainsnak: {
+                    snaktype: "value",
+                    property: "P217",
+                    datavalue: {
+                      value: IAItemMetaData.bookid,
+                      type: "string",
+                    },
+                  },
+                  type: "statement",
+                  rank: "normal",
+                },
+              ]
+            : undefined,
+          collection: [
+            {
+              mainsnak: {
+                snaktype: "value",
+                property: "P195",
+                datavalue: {
+                  value: {
+                    "entity-type": "item",
+                    "numeric-id": 39162,
+                    id: "Q39162", //wikidataID for 'opensource'
+                  },
+                  type: "wikibase-entityid",
+                },
+              },
+              type: "statement",
+              rank: "normal",
+            },
+          ],
+          title: IAItemMetaData.title
+            ? [
+                {
+                  mainsnak: {
+                    snaktype: "value",
+                    property: "P1476",
+                    datavalue: {
+                      value: {
+                        text: IAItemMetaData.title,
+                        language: "en",
+                      },
+                      type: "monolingualtext",
+                    },
+                  },
+                  type: "statement",
+                  rank: "normal",
+                },
+              ]
+            : undefined,
+          name: IAItemMetaData.title
+            ? [
+                {
+                  mainsnak: {
+                    snaktype: "value",
+                    property: "P2561",
+                    datavalue: {
+                      value: {
+                        text: IAItemMetaData.title,
+                        language: "en",
+                      },
+                      type: "monolingualtext",
+                    },
+                  },
+                  type: "statement",
+                  rank: "normal",
+                },
+              ]
+            : undefined,
+          file_format: [
+            {
+              mainsnak: {
+                snaktype: "value",
+                property: "P2701",
+                datavalue: {
+                  value: {
+                    "entity-type": "item",
+                    "numeric-id": 42332,
+                    id: "Q42332", // wikidataID for PDF
+                  },
+                  type: "wikibase-entityid",
+                },
+              },
+              type: "statement",
+              rank: "normal",
+            },
+          ],
+          author_name: IAItemMetaData.author
+            ? [
+                {
+                  mainsnak: {
+                    snaktype: "value",
+                    property: "P2093",
+                    datavalue: {
+                      value: IAItemMetaData.author,
+                      type: "string",
+                    },
+                  },
+                  type: "statement",
+                  rank: "normal",
+                },
+              ]
+            : undefined,
+          URL: [
+            {
+              mainsnak: {
+                snaktype: "value",
+                property: "P2699",
+                datavalue: {
+                  value: `https://commons.wikimedia.org/wiki/File:${commonsItemFilename}`,
+                  type: "string",
+                },
+              },
+              type: "statement",
+              rank: "normal",
+            },
+          ],
+          copyright_status: [
+            {
+              mainsnak: {
+                snaktype: "value",
+                property: "P6216",
+                datavalue: {
+                  value: {
+                    "entity-type": "item",
+                    "numeric-id": 6938433,
+                    id: "Q6938433", // wikidataID for CC0 license
+                  },
+                  type: "wikibase-entityid",
+                },
+              },
+              type: "statement",
+              rank: "normal",
+            },
+          ],
+        },
+      };
+
+      const res = await bot.request({
+        action: "wbeditentity",
+        new: "item",
+        summary: "bub2.toolforge.org: upload commons item to wikidata",
+        tags: "wikimedia-commons-app",
+        data: JSON.stringify(payload),
+        token: csrf_token,
+      });
+
+      logger.log({
+        level: "info",
+        message: `Polling - uploadToWikidata: Upload of ${commonsItemFilename} metadata to wikidata successful`,
+      });
+      return res.entity.id;
+    } catch (error) {
+      logger.log({
+        level: "error",
+        message: `Polling - uploadToWikidata: Failed to upload  ${commonsItemFilename} to wikidata: ${error}`,
+      });
+      return 404;
+    }
+  }
+  return await getCsrfToken();
+}
+
+/**
+ * The function `updateCommons` updates the file on Wikimedia Commons
+ * with its corresponding Wikidata ID in order to complete the sync
+ * @param commonsItemFilename - The `commonsItemFilename` parameter is the name of the file on
+ * Wikimedia Commons that you want to update. It should include the "File:" prefix.
+ * @param wikidataId - The `wikidataId` parameter is the identifier of the item on Wikidata. It is used
+ * to link the file on Wikimedia Commons to the corresponding item on Wikidata, which contains
+ * structured data about the file.
+ * @param IAItemMetaData - IAItemMetaData is an object that contains metadata information about an item
+ * from the Internet Archive.
+ */
+async function updateCommons(commonsItemFilename, wikidataId, IAItemMetaData) {
+  try {
+    const bot = await Mwn.init({
+      apiUrl: "https://commons.wikimedia.org/w/api.php",
+      username: process.env.EMAIL_BOT_USERNAME,
+      password: process.env.EMAIL_BOT_PASSWORD,
+      userAgent: "bub2.toolforge ([[https://bub2.toolforge.org]])",
+      defaultParams: {
+        assert: "user",
+      },
+    });
+    const IAItemPermission = IAItemMetaData.metadata.licenseurl
+      ? `CCO No Rights Reserved ${IAItemMetaData.metadata.licenseurl}`
+      : "CC0 No Rights Reserved. Provided at no cost and free to use https://archive.org/about/terms.php";
+
+    await bot.edit(`File:${commonsItemFilename}`, () => {
+      const text = `{{Book
+|Author=${IAItemMetaData.metadata.author}
+|Title=${IAItemMetaData.metadata.title}
+|Description=${IAItemMetaData.metadata.description}
+|Language=${IAItemMetaData.metadata.language}
+|Publication Date=${IAItemMetaData.metadata.addeddate}
+|Source=${IAItemMetaData.metadata["identifier-access"]}
+|Publisher=${IAItemMetaData.metadata.publisher}
+|Permission=${IAItemPermission}
+|Wikidata=${wikidataId}
+|Other_fields_1={{Information field|name=Contributor|value=${IAItemMetaData.metadata.contributor}|name=Pages|value=${IAItemMetaData.metadata.pages}|name=Internet_Archive_Identifier|value=${IAItemMetaData.metadata.identifier}}}
+}}
+{{cc-zero}}
+[[Category:bub.wikimedia]]
+`;
+      return text;
+    });
+    logger.log({
+      level: "info",
+      message: `Polling - updateCommons: Successfully updated ${commonsItemFilename}`,
+    });
+  } catch (error) {
+    logger.log({
+      level: "error",
+      message: `Polling - updateCommons: Failed to update ${commonsItemFilename}: ${error}`,
+    });
+  }
+}
+
+async function handlePolling() {
+  const {
+    IAItemMetaData,
+    IADownloadURL_PDF,
+  } = await getIAMetadataAndDownloadUrl();
+  const commonsItemFilename = await uploadToCommons(
+    IAItemMetaData,
+    IADownloadURL_PDF
+  );
+  if (commonsItemFilename !== 404) {
+    const wikidataId = await uploadToWikidata(
+      IAItemMetaData.metadata,
+      commonsItemFilename
+    );
+    if (wikidataId !== 404) {
+      await updateCommons(commonsItemFilename, wikidataId, IAItemMetaData);
+    }
+  }
+}
+
+module.exports = handlePolling;

--- a/server.js
+++ b/server.js
@@ -54,6 +54,7 @@ const TroveProducer = require("./bull/trove-queue/producer");
 const { exec } = require("child_process");
 const config = require("./utils/bullconfig");
 const _ = require("lodash");
+const handlePolling = require("./polling.js");
 
 app
   .prepare()
@@ -277,15 +278,15 @@ app
                     .toString()
                     .padStart(2, "0") +
                   "-" +
-                  date
-                    .getUTCDate()
-                    .toLocaleString(undefined, { minimumIntegerDigits: 2 }) +
+                  date.getUTCDate().toLocaleString(undefined, {
+                    minimumIntegerDigits: 2,
+                  }) +
                   " " +
                   date.getUTCHours() +
                   ":" +
-                  date
-                    .getUTCMinutes()
-                    .toLocaleString(undefined, { minimumIntegerDigits: 2 }) +
+                  date.getUTCMinutes().toLocaleString(undefined, {
+                    minimumIntegerDigits: 2,
+                  }) +
                   " (UTC)",
                 upload_progress: job.progress(),
                 status: returnJobStatus(
@@ -590,6 +591,7 @@ app
         })();
       }
     });
+    setInterval(handlePolling, 30 * 60 * 1000);
   })
   .catch((ex) => {
     console.error(ex.stack);

--- a/utils/handleZipToCommons.js
+++ b/utils/handleZipToCommons.js
@@ -1,0 +1,111 @@
+const fs = require("fs");
+const JSZip = require("jszip");
+const PDFDocument = require("pdfkit");
+const path = require("path");
+const { PDFDocument: PDFLibDocument } = require("pdf-lib");
+const winston = require("winston");
+const { customFetch } = require("./helper");
+const logger = winston.loggers.get("defaultLogger");
+
+/**
+ * The function `handleZipToCommons` takes a download URL for a zip file from IA, extracts the images from the
+ * zip file, converts them to PDF format, merges the PDFs into a single document, and saves the
+ * resulting PDF file locally.
+ * @param IADownloadURL_File - The parameter `IADownloadURL_File` is the URL of a file from IA that needs to be
+ * downloaded. It is used in the `zipToPdf` function to fetch the zip file and convert it to PDF.
+ * @returns The function `handleZipToCommons` returns a promise that resolves to a status code (either
+ * 200 or 404).
+ */
+async function handleZipToCommons(IADownloadURL_File) {
+  async function mergePdf(pdfDataArray) {
+    try {
+      const mergedPdf = await PDFLibDocument.create();
+      for (const pdfData of pdfDataArray) {
+        const pdfDoc = await PDFLibDocument.load(pdfData);
+        const pages = await mergedPdf.copyPages(
+          pdfDoc,
+          pdfDoc.getPageIndices()
+        );
+        for (const page of pages) {
+          mergedPdf.addPage(page);
+        }
+      }
+
+      const mergedPdfFile = await mergedPdf.save();
+      await fs.promises.writeFile("commonsPayload.pdf", mergedPdfFile);
+      logger.log({
+        level: "info",
+        message: `Polling -  handleZipToCommons: Successfully saved file from  ${IADownloadURL_File} to local`,
+      });
+      return 200;
+    } catch (error) {
+      logger.log({
+        level: "error",
+        message: `Polling -  handleZipToCommons/mergePdf: ${error}`,
+      });
+      return 404;
+    }
+  }
+
+  async function zipToPdf() {
+    try {
+      const res = await customFetch(
+        `${IADownloadURL_File}`,
+        "GET",
+        new Headers({
+          "Content-Type": "application/zip",
+        }),
+        "file"
+      );
+
+      const buffer = await res.buffer();
+      const zip = await JSZip.loadAsync(buffer);
+      const pdfInstances = [];
+
+      await Promise.all(
+        Object.values(zip.files).map(async (file, index) => {
+          if (file.dir) return;
+          if ([".jpg", ".jpeg", ".png"].includes(path.extname(file.name))) {
+            const data = await file.async("nodebuffer");
+            const pdfDoc = new PDFDocument();
+            const buffers = [];
+            const writeStream = new require("stream").Writable({
+              write(chunk, encoding, callback) {
+                buffers.push(chunk);
+                callback();
+              },
+            });
+            pdfDoc.pipe(writeStream);
+            pdfDoc.image(data, 0, 0, { fit: [595.28, 841.89] }); // A4 size
+            pdfDoc.end();
+            return new Promise((resolve) => {
+              writeStream.on("finish", () => {
+                pdfInstances.push({
+                  index,
+                  pdfInstance: Buffer.concat(buffers),
+                });
+                resolve();
+              });
+            });
+          }
+        })
+      );
+
+      pdfInstances.sort((a, b) => a.index - b.index);
+
+      const sortedPdfInstances = pdfInstances.map(
+        ({ pdfInstance }) => pdfInstance
+      );
+      return await mergePdf(sortedPdfInstances);
+    } catch (error) {
+      logger.log({
+        level: "error",
+        message: `Polling -  handleZipToCommons/zipToPdf: ${error}`,
+      });
+      return 404;
+    }
+  }
+  return await zipToPdf();
+}
+
+module.exports = handleZipToCommons;

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -25,7 +25,12 @@ module.exports = {
     return title.replace(/[ \(\)\[\],:]/g, "");
   },
 
-  customFetch: async (URI, method = "GET", headers = new Headers()) => {
+  customFetch: async (
+    URI,
+    method = "GET",
+    headers = new Headers(),
+    contentType = "other"
+  ) => {
     return fetch(URI, {
       method: method,
       headers: headers,
@@ -34,7 +39,10 @@ module.exports = {
         (res) => {
           if (res.status === 404) {
             return 404;
-          } else return res.json();
+          } else {
+            const result = contentType === "file" ? res : res.json();
+            return result;
+          }
         },
         (err) => {
           logger.log({


### PR DESCRIPTION
Fixes: [T346386](https://phabricator.wikimedia.org/T346386)

## Proposed Changes
- Set up a polling mechanism to get .djvu files from Internet Archive
- Integrate MediaWiki API to upload the .djvu file and metadata to Commons
- Integrate Wikidata API to cite the metadata correctly so that it can be reused in Wikisource and other places

## Code Walkthrough
### **INTERNET ARCHIVE TO COMMONS**
- The `getIAMetadataAndDownloadUrl` function queries the IA Advanced Search API and returns an array of all items uploaded by `bub.wikimedia`. Using the `count` variable stored on redis (via Bull) as its index it then selects and returns an item(`identifier`) from the array. Using the `identifier` it retrieves the corresponding metadata from IA and returns an object that contains the metadata of selected IA item and the download url of its pdf or zip file
- The function `uploadToCommons` uploads the file and metadata returned from `getIAMetadataAndDownloadUrl` to Wikimedia Commons using the Mwn toolforge package. After successful upload, it updates the `count` variable stored on redis (via Bull) while returning the Commons filename of the uploaded file
For PDF format, the file is uploaded to Commons directly from the PDF URL, For ZIP format, `handleZipToCommons` utility fn is used to save and convert the ZIP file to PDF , and then uploaded to Commons from local file

### **COMMONS TO WIKIDATA**
- The function `uploadToWikidata` uploads the metadata initially uploaded to Commons by `uploadToCommons` to Wikidata using the Mwn toolforge package. It returns the wikidata ID of the newly created wikidata entity

### **ADD WIKIDATA_ID TO PREVIOUSLY CREATED COMMONS ITEM**
- The function `updateCommons` updates the file on Wikimedia Commons with the Wikidata ID returned by `uploadToWikidata`  in order to complete the sync

Comments and links to relevant Docs have been added to each function inside the code for more clarity

### **IMPORTANT NOTE**
- If need be, you can directly set const IACurrentIndex = [any number between 0 and 326] to select a particular identifier for testing.
- The polling starts from the most recent files to the oldest. (eg index 0 is the most recent upload to IA)
- Some Items from IA have incomplete metadata. those missing metadata will appear as undefined in Commons
- You could also see an error like this in `error.log` -  fileexists-no-change: The upload is an exact duplicate of the current version of `filename`. Which means the file has already been uploaded by me during testing. Am not sure but this error might not appear since it is being uploaded from different bot accounts

## Files Created/Updated
- polling.js - Implement the polling functions
- server.js - Call handlePolling after the server has started and run it at 30 minutes interval
- utils/handleZipToCommons - Implement a utility function to handle ZIP files upload to commons
- utils/helper - Update `customFetch` to return the correct format if the response is a file
- package.json - Add mwn toolforge and pdf-lib packages

## Images

### **Lughat Firozi.pdf in Commons**
![common1](https://github.com/coderwassananmol/BUB2/assets/65835404/4259db25-ebcf-4eca-8f5b-57720cae1195)
![common2](https://github.com/coderwassananmol/BUB2/assets/65835404/d23de402-de74-4455-b6ae-1474afc878c3)
![common3](https://github.com/coderwassananmol/BUB2/assets/65835404/c3c355c1-17bc-4206-a7cd-f795834eba4a)



### **Lughat Firozi.pdf in Wikidata**
![wikidata1](https://github.com/coderwassananmol/BUB2/assets/65835404/e72c6eb6-7c0d-49d8-9edc-95d088e85b7d)

![wikidata2](https://github.com/coderwassananmol/BUB2/assets/65835404/02be47ab-d378-4f0e-aaf4-3f71d06f38bb)

![wikidata4](https://github.com/coderwassananmol/BUB2/assets/65835404/c2b87e1c-8e6d-4bd9-b8a0-192905fdfff6)

![wikidata3](https://github.com/coderwassananmol/BUB2/assets/65835404/524a2115-b825-45f9-a227-ab5d62d623a8)


## Checklist 
- [x] Coding Conventions are followed.
- [x] Comments are used for Documenting the Code.
- [x] Correct File Names are mentioned.

