### PR TITLE
HOTFIX: Internet Archive Link not showing on ShowJobInformation queue Modal

### DIFF
--- a/bull/google-books-queue/consumer.js
+++ b/bull/google-books-queue/consumer.js
@@ -95,6 +95,10 @@ GoogleBooksQueue.process((job, done) => {
           }
           done(new Error(errorMessage));
         } else {
+          job.progress({
+            step: "Upload To IA",
+            value: `(${100}%)`,
+          });
           if (
             job.data.isUploadCommons !== "true" &&
             job.data.isEmailNotification !== "true"

--- a/bull/trove-queue/consumer.js
+++ b/bull/trove-queue/consumer.js
@@ -103,6 +103,10 @@ TroveQueue.process((job, done) => {
                 }
                 done(new Error(errorMessage));
               } else {
+                job.progress({
+                  step: "Upload To IA",
+                  value: `(${100}%)`,
+                });
                 if (
                   isEmailNotification === "true" &&
                   job.data.details.isUploadCommons !== "true"

--- a/bull/trove-queue/producer.js
+++ b/bull/trove-queue/producer.js
@@ -16,7 +16,8 @@ module.exports = async (
   userName,
   isEmailNotification,
   isUploadCommons,
-  oauthToken
+  oauthToken,
+  commonsMetadata
 ) => {
   const uri = `https://trove.nla.gov.au/newspaper/article/${bookid}`;
   var options = {
@@ -35,6 +36,7 @@ module.exports = async (
   metaData["isEmailNotification"] = isEmailNotification;
   metaData["isUploadCommons"] = isUploadCommons;
   metaData["oauthToken"] = oauthToken;
+  metaData["commonsMetadata"] = commonsMetadata;
 
   const details = {
     details: metaData,

--- a/components/Books.js
+++ b/components/Books.js
@@ -270,7 +270,7 @@ const Books = () => {
             session.user.name
           }&IAtitle=${IAIdentifier}&isUploadCommons=${isUploadCommons}&oauthToken=${
             session?.accessToken
-          }&isEmailNotification=${isEmailNotification}`;
+          }&isEmailNotification=${isEmailNotification}&commonsMetadata=${commonsMetadata}`;
           fetch(url)
             .then((res) => res.json())
             .then((response) => {

--- a/server.js
+++ b/server.js
@@ -169,7 +169,9 @@ app
               ),
               uploadStatus: {
                 uploadLink:
-                  job.progress().step.includes("Upload To IA (100%)") && trueURI
+                  (job.progress().step.includes("Upload To IA") ||
+                    job.progress().step.includes("Upload to Wikimedia")) &&
+                  trueURI
                     ? trueURI
                     : "",
                 isUploaded: jobState === "completed" ? true : false,
@@ -570,7 +572,8 @@ app
                   userName,
                   isEmailNotification,
                   isUploadCommons,
-                  oauthToken
+                  oauthToken,
+                  commonsMetadata
                 );
               }
             }


### PR DESCRIPTION
This PR fixes the following issues:

Internet Archive Link not showing on queue modal when uploadToCommons is successful
Commons metadata not being sent correctly for trove