### PR TITLE
[Fixes:T357582] Integrate Google Books and Trove with WikiData

### DIFF
--- a/bull/google-books-queue/consumer.js
+++ b/bull/google-books-queue/consumer.js
@@ -95,6 +95,10 @@ GoogleBooksQueue.process((job, done) => {
           }
           done(new Error(errorMessage));
         } else {
+          job.progress({
+            step: "Upload To IA",
+            value: `(${100}%)`,
+          });
           if (
             job.data.isUploadCommons !== "true" &&
             job.data.isEmailNotification !== "true"
@@ -121,7 +125,11 @@ GoogleBooksQueue.process((job, done) => {
                   step: "Upload to Wikimedia Commons",
                   value: `(${100}%)`,
                   wikiLinks: {
-                    commons: await commonsResponse.value.filename,
+                    commons: await commonsResponse.value.commons.filename,
+                    wikidata:
+                      (await commonsResponse.value.wikidata) !== 404
+                        ? await commonsResponse.value.wikidata
+                        : 404,
                   },
                 });
                 if (job.data.isEmailNotification === "true") {

--- a/bull/google-books-queue/consumer.js
+++ b/bull/google-books-queue/consumer.js
@@ -130,6 +130,10 @@ GoogleBooksQueue.process((job, done) => {
                       (await commonsResponse.value.wikidata) !== 404
                         ? await commonsResponse.value.wikidata
                         : 404,
+                    wikisource:
+                      (await commonsResponse.value.wikisource) !== 404
+                        ? await commonsResponse.value.wikisource.filename
+                        : 404,
                   },
                 });
                 if (job.data.isEmailNotification === "true") {

--- a/bull/trove-queue/consumer.js
+++ b/bull/trove-queue/consumer.js
@@ -103,6 +103,16 @@ TroveQueue.process((job, done) => {
                 }
                 done(new Error(errorMessage));
               } else {
+                job.progress({
+                  step: "Upload To IA",
+                  value: `(${100}%)`,
+                });
+                if (
+                  isEmailNotification !== "true" &&
+                  job.data.details.isUploadCommons !== "true"
+                ) {
+                  done(null, true);
+                }
                 if (
                   isEmailNotification === "true" &&
                   job.data.details.isUploadCommons !== "true"
@@ -124,9 +134,14 @@ TroveQueue.process((job, done) => {
                       if (commonsResponse.status === true) {
                         job.progress({
                           step: "Upload to Wikimedia Commons",
-                          value: `(100%)`,
+                          value: `(${100}%)`,
                           wikiLinks: {
-                            commons: await commonsResponse.value.filename,
+                            commons: await commonsResponse.value.commons
+                              .filename,
+                            wikidata:
+                              (await commonsResponse.value.wikidata) !== 404
+                                ? await commonsResponse.value.wikidata
+                                : 404,
                           },
                         });
                         if (job.data.isEmailNotification === "true") {
@@ -134,7 +149,10 @@ TroveQueue.process((job, done) => {
                           EmailProducer(
                             userName,
                             name,
-                            { archiveLink: trueURI, commonsLink: commonsLink },
+                            {
+                              archiveLink: trueURI,
+                              commonsLink: commonsLink,
+                            },
                             { archive: true, commons: true }
                           );
                         }

--- a/components/ShowJobInformation.js
+++ b/components/ShowJobInformation.js
@@ -144,10 +144,10 @@ const ShowJobInformation = (props) => {
           </CardActions>
 
           <CardActions sx={{ marginTop: "-15px" }}>
-            {data.wikimedia_links !== "Not Integrated" ? (
+            {data.wikimedia_links.commons !== "Not Integrated" ? (
               <Link
                 passHref
-                href={`https://commons.wikimedia.org/wiki/File:${data.wikimedia_links}`}
+                href={`https://commons.wikimedia.org/wiki/File:${data.wikimedia_links.commons}`}
               >
                 <Button
                   sx={styles.button}
@@ -156,6 +156,23 @@ const ShowJobInformation = (props) => {
                   color="primary"
                 >
                   View on Wikimedia Commons
+                </Button>
+              </Link>
+            ) : null}
+          </CardActions>
+          <CardActions sx={{ marginTop: "-15px" }}>
+            {data.wikimedia_links.wikidata !== "Not Integrated" ? (
+              <Link
+                passHref
+                href={`https://www.wikidata.org/wiki/${data.wikimedia_links.wikidata}`}
+              >
+                <Button
+                  sx={styles.button}
+                  target="_blank"
+                  size="large"
+                  color="primary"
+                >
+                  View on Wikidata
                 </Button>
               </Link>
             ) : null}

--- a/components/ShowJobInformation.js
+++ b/components/ShowJobInformation.js
@@ -18,7 +18,8 @@ const ShowJobInformation = (props) => {
   const styles = {
     root: {
       maxWidth: 365,
-      height: "fit-content",
+      height: "95vh",
+      overflow: "scroll",
     },
     cardContentContainer: {
       height: "200px",
@@ -173,6 +174,24 @@ const ShowJobInformation = (props) => {
                   color="primary"
                 >
                   View on Wikidata
+                </Button>
+              </Link>
+            ) : null}
+          </CardActions>
+
+          <CardActions sx={{ marginTop: "-15px" }}>
+            {data.wikimedia_links.wikisource !== "Not Integrated" ? (
+              <Link
+                passHref
+                href={`https://en.wikisource.org/wiki/File:${data.wikimedia_links.wikisource}`}
+              >
+                <Button
+                  sx={styles.button}
+                  target="_blank"
+                  size="large"
+                  color="primary"
+                >
+                  View on WikiSource
                 </Button>
               </Link>
             ) : null}

--- a/server.js
+++ b/server.js
@@ -180,9 +180,16 @@ app
                 commons: job.progress().wikiLinks?.commons
                   ? job.progress().wikiLinks.commons
                   : "Not Integrated",
-                wikidata: job.progress().wikiLinks?.wikidata
-                  ? job.progress().wikiLinks.wikidata
-                  : "Not Integrated",
+                wikidata:
+                  job.progress().wikiLinks?.wikidata &&
+                  job.progress().wikiLinks.wikidata !== 404
+                    ? job.progress().wikiLinks.wikidata
+                    : "Not Integrated",
+                wikisource:
+                  job.progress().wikiLinks?.wikisource &&
+                  job.progress().wikiLinks.wikisource !== 404
+                    ? job.progress().wikiLinks.wikisource
+                    : "Not Integrated",
               },
             };
             res.send(

--- a/server.js
+++ b/server.js
@@ -169,14 +169,21 @@ app
               ),
               uploadStatus: {
                 uploadLink:
-                  job.progress().step.includes("Upload To IA (100%)") && trueURI
+                  (job.progress().step.includes("Upload To IA") ||
+                    job.progress().step.includes("Upload to Wikimedia")) &&
+                  trueURI
                     ? trueURI
                     : "",
                 isUploaded: jobState === "completed" ? true : false,
               },
-              wikimedia_links: job.progress().wikiLinks?.commons
-                ? job.progress().wikiLinks.commons
-                : "Not Integrated",
+              wikimedia_links: {
+                commons: job.progress().wikiLinks?.commons
+                  ? job.progress().wikiLinks.commons
+                  : "Not Integrated",
+                wikidata: job.progress().wikiLinks?.wikidata
+                  ? job.progress().wikiLinks.wikidata
+                  : "Not Integrated",
+              },
             };
             res.send(
               Object.assign(

--- a/utils/helper.js
+++ b/utils/helper.js
@@ -390,12 +390,12 @@ module.exports = {
                 rank: "normal",
               },
             ],
-            inventory_number: id
+            internet_archive_id: id
               ? [
                   {
                     mainsnak: {
                       snaktype: "value",
-                      property: "P217",
+                      property: "P724",
                       datavalue: {
                         value: id,
                         type: "string",


### PR DESCRIPTION
Fixes: [T357582](https://phabricator.wikimedia.org/T357582)

## Proposed Changes
- If Upload to Commons and WikiData is successful, a corresponding page should also be created on WikiSource
- The WikiSource Link should be shown together with the Commons and WikiData Link in the queue modal

## Files Created/Updated
- utils/helper.js - add uploadToWikiSource function and logic
- bull/commons-queue/consumer.js - call uploadToWikiSource function if upload to Commons and WikiData is successful
- bull/google-books-queue/consumer.js - send WikiSource return value to server.js
- bull/trove-queue/consumer.js - send WikiSource return value to server.js 
- components/ShowJobInformation - display WikiSource link on queue modal
- server.js - receive WikiSource return value and send to client


## Images




